### PR TITLE
docs: remove previous IRC from both README and Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,3 @@ notifications:
   email:
     on_success: never
     on_failure: always
-
-  irc:
-    channels:
-      - "chat.freenode.net#wifiphisher"
-    use_notice: true

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 [![Documentation Status](https://readthedocs.org/projects/wifiphisher/badge/?version=latest)](http://wifiphisher.readthedocs.io/en/latest/?badge=latest)
 ![Python Version](https://img.shields.io/badge/python-2.7-blue.svg)
 ![License](https://img.shields.io/badge/license-GPL-blue.svg)
-[![Chat IRC](https://img.shields.io/badge/chat-IRC-ff69b4.svg)](https://webchat.freenode.net/?channels=%23wifiphisher)
 
 <p align="center"><img src="https://wifiphisher.github.io/wifiphisher/wifiphisher.png" /></p>
 


### PR DESCRIPTION
Remove the IRC channel from both `README` and `Travis` since it was `wifiphisher`'s channel.